### PR TITLE
デザインシステム更新: DESIGN.md仕様への全ファイル準拠

### DIFF
--- a/docs/assets/sample-gradient.svg
+++ b/docs/assets/sample-gradient.svg
@@ -1,12 +1,101 @@
-<svg width="240" height="120" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120">
   <defs>
-    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#bfdbfe"/>
-      <stop offset="50%" stop-color="#ddd6fe"/>
-      <stop offset="100%" stop-color="#fde68a"/>
+
+    <linearGradient id="base" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c0a1e"></stop>
+      <stop offset="50%" stop-color="#1a0a3e"></stop>
+      <stop offset="100%" stop-color="#0a1628"></stop>
     </linearGradient>
+
+    <radialGradient id="glow-center" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.9"></stop>
+      <stop offset="40%" stop-color="#6d28d9" stop-opacity="0.5"></stop>
+      <stop offset="100%" stop-color="#4c1d95" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glow-left" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.85"></stop>
+      <stop offset="50%" stop-color="#2563eb" stop-opacity="0.4"></stop>
+      <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glow-right" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ec4899" stop-opacity="0.85"></stop>
+      <stop offset="50%" stop-color="#db2777" stop-opacity="0.4"></stop>
+      <stop offset="100%" stop-color="#be185d" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glow-top" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.7"></stop>
+      <stop offset="60%" stop-color="#0891b2" stop-opacity="0.3"></stop>
+      <stop offset="100%" stop-color="#0e7490" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glow-bottom" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.6"></stop>
+      <stop offset="60%" stop-color="#d97706" stop-opacity="0.25"></stop>
+      <stop offset="100%" stop-color="#b45309" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"></stop>
+      <stop offset="30%" stop-color="#e9d5ff" stop-opacity="0.7"></stop>
+      <stop offset="70%" stop-color="#c4b5fd" stop-opacity="0.3"></stop>
+      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="rim" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#a5f3fc" stop-opacity="0.5"></stop>
+      <stop offset="100%" stop-color="#a5f3fc" stop-opacity="0"></stop>
+    </radialGradient>
+    <filter id="blur-sm">
+      <feGaussianBlur stdDeviation="2"></feGaussianBlur>
+    </filter>
+    <filter id="blur-md">
+      <feGaussianBlur stdDeviation="4"></feGaussianBlur>
+    </filter>
   </defs>
-  <rect width="240" height="120" fill="url(#grad)"/>
-  <circle cx="80" cy="60" r="35" fill="#fff" opacity=".25"/>
-  <circle cx="160" cy="60" r="35" fill="#fff" opacity=".25"/>
+
+
+  <rect width="240" height="120" fill="url(#base)"></rect>
+
+
+  <circle cx="30" cy="12" r="1" fill="rgba(255,255,255,0.6)"></circle>
+  <circle cx="72" cy="8" r="0.8" fill="rgba(255,255,255,0.5)"></circle>
+  <circle cx="170" cy="10" r="1.2" fill="rgba(255,255,255,0.7)"></circle>
+  <circle cx="210" cy="6" r="0.8" fill="rgba(255,255,255,0.4)"></circle>
+  <circle cx="226" cy="22" r="1" fill="rgba(255,255,255,0.5)"></circle>
+  <circle cx="16" cy="50" r="0.8" fill="rgba(255,255,255,0.4)"></circle>
+  <circle cx="228" cy="88" r="1" fill="rgba(255,255,255,0.45)"></circle>
+  <circle cx="50" cy="108" r="0.8" fill="rgba(255,255,255,0.35)"></circle>
+  <circle cx="190" cy="115" r="1" fill="rgba(255,255,255,0.4)"></circle>
+
+
+  <ellipse cx="60" cy="60" rx="70" ry="55" fill="url(#glow-left)" filter="url(#blur-md)"></ellipse>
+  <ellipse cx="180" cy="60" rx="70" ry="55" fill="url(#glow-right)" filter="url(#blur-md)"></ellipse>
+  <ellipse cx="120" cy="20" rx="60" ry="40" fill="url(#glow-top)" filter="url(#blur-md)"></ellipse>
+  <ellipse cx="120" cy="100" rx="55" ry="35" fill="url(#glow-bottom)" filter="url(#blur-md)"></ellipse>
+
+
+  <ellipse cx="120" cy="60" rx="90" ry="65" fill="url(#glow-center)"></ellipse>
+
+
+  <ellipse cx="120" cy="60" rx="45" ry="32" fill="none" stroke="rgba(167,139,250,0.35)" stroke-width="1.5"></ellipse>
+  <ellipse cx="120" cy="60" rx="62" ry="44" fill="none" stroke="rgba(167,139,250,0.15)" stroke-width="1"></ellipse>
+
+
+  <ellipse cx="105" cy="48" rx="18" ry="12" fill="url(#rim)" filter="url(#blur-sm)"></ellipse>
+
+
+  <ellipse cx="120" cy="60" rx="28" ry="20" fill="url(#core)" filter="url(#blur-sm)"></ellipse>
+
+
+  <circle cx="120" cy="60" r="6" fill="rgba(255,255,255,0.9)"></circle>
+  <circle cx="120" cy="60" r="3" fill="#ffffff"></circle>
+
+
+  <line x1="120" y1="0" x2="120" y2="120" stroke="rgba(255,255,255,0.06)" stroke-width="1.5"></line>
+  <line x1="0" y1="60" x2="240" y2="60" stroke="rgba(255,255,255,0.06)" stroke-width="1.5"></line>
+  <line x1="40" y1="0" x2="200" y2="120" stroke="rgba(255,255,255,0.03)" stroke-width="1"></line>
+  <line x1="200" y1="0" x2="40" y2="120" stroke="rgba(255,255,255,0.03)" stroke-width="1"></line>
 </svg>

--- a/docs/assets/sample-landscape.svg
+++ b/docs/assets/sample-landscape.svg
@@ -1,13 +1,89 @@
-<svg width="240" height="120" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120">
   <defs>
+
     <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#bfdbfe"/>
-      <stop offset="100%" stop-color="#e0f2fe"/>
+      <stop offset="0%" stop-color="#1e3a8a"></stop>
+      <stop offset="60%" stop-color="#3b82f6"></stop>
+      <stop offset="100%" stop-color="#93c5fd"></stop>
     </linearGradient>
+
+    <linearGradient id="ground" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#16a34a"></stop>
+      <stop offset="100%" stop-color="#14532d"></stop>
+    </linearGradient>
+
+    <linearGradient id="mountain1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"></stop>
+      <stop offset="30%" stop-color="#cbd5e1"></stop>
+      <stop offset="100%" stop-color="#64748b"></stop>
+    </linearGradient>
+    <linearGradient id="mountain2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e2e8f0"></stop>
+      <stop offset="35%" stop-color="#94a3b8"></stop>
+      <stop offset="100%" stop-color="#475569"></stop>
+    </linearGradient>
+    <linearGradient id="mountain3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#334155"></stop>
+      <stop offset="100%" stop-color="#1e293b"></stop>
+    </linearGradient>
+
+    <radialGradient id="sun" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fef08a"></stop>
+      <stop offset="50%" stop-color="#facc15"></stop>
+      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"></stop>
+    </radialGradient>
   </defs>
-  <rect width="240" height="120" fill="url(#sky)"/>
-  <ellipse cx="120" cy="130" rx="100" ry="40" fill="#86efac"/>
-  <circle cx="60" cy="38" r="18" fill="#fde68a"/>
-  <ellipse cx="160" cy="50" rx="28" ry="16" fill="#fff" opacity=".8"/>
-  <ellipse cx="185" cy="46" rx="20" ry="12" fill="#fff" opacity=".7"/>
+
+
+  <rect width="240" height="120" fill="url(#sky)"></rect>
+
+
+  <ellipse cx="190" cy="32" rx="22" ry="22" fill="url(#sun)" opacity="0.5"></ellipse>
+
+  <circle cx="190" cy="32" r="12" fill="#fde047"></circle>
+  <circle cx="190" cy="32" r="9" fill="#fef08a"></circle>
+
+
+  <g opacity="0.6">
+    <ellipse cx="60" cy="28" rx="28" ry="9" fill="#e0f2fe"></ellipse>
+    <ellipse cx="45" cy="30" rx="16" ry="7" fill="#e0f2fe"></ellipse>
+    <ellipse cx="75" cy="31" rx="14" ry="6" fill="#e0f2fe"></ellipse>
+  </g>
+
+
+  <g opacity="0.9">
+    <ellipse cx="130" cy="20" rx="22" ry="8" fill="#f0f9ff"></ellipse>
+    <ellipse cx="115" cy="22" rx="13" ry="6" fill="#f0f9ff"></ellipse>
+    <ellipse cx="146" cy="22" rx="11" ry="5" fill="#f0f9ff"></ellipse>
+  </g>
+
+
+  <polygon points="160,78 200,40 240,78" fill="url(#mountain3)"></polygon>
+
+
+  <polygon points="40,78 95,28 150,78" fill="url(#mountain2)"></polygon>
+
+  <polygon points="75,42 95,28 115,42" fill="#f8fafc" opacity="0.9"></polygon>
+
+
+  <polygon points="80,78 140,18 200,78" fill="url(#mountain1)"></polygon>
+
+  <polygon points="118,32 140,18 162,32" fill="#ffffff"></polygon>
+  <polygon points="122,36 140,18 158,36" fill="#f1f5f9" opacity="0.7"></polygon>
+
+
+  <rect x="0" y="78" width="240" height="42" fill="url(#ground)"></rect>
+
+  <ellipse cx="60" cy="78" rx="70" ry="8" fill="#15803d"></ellipse>
+  <ellipse cx="180" cy="78" rx="80" ry="6" fill="#166534"></ellipse>
+
+
+  <rect x="28" y="74" width="4" height="16" fill="#713f12"></rect>
+  <ellipse cx="30" cy="70" rx="10" ry="11" fill="#15803d"></ellipse>
+  <ellipse cx="30" cy="67" rx="7" ry="8" fill="#16a34a"></ellipse>
+
+
+  <rect x="205" y="72" width="4" height="18" fill="#713f12"></rect>
+  <ellipse cx="207" cy="68" rx="11" ry="12" fill="#14532d"></ellipse>
+  <ellipse cx="207" cy="65" rx="8" ry="9" fill="#15803d"></ellipse>
 </svg>

--- a/docs/assets/sample-pattern.svg
+++ b/docs/assets/sample-pattern.svg
@@ -1,8 +1,77 @@
-<svg width="240" height="120" viewBox="0 0 240 120" xmlns="http://www.w3.org/2000/svg">
-  <rect width="240" height="120" fill="#f1f5f9"/>
-  <rect x="20" y="20" width="40" height="40" rx="4" fill="#2563eb" opacity=".7"/>
-  <circle cx="140" cy="40" r="20" fill="#f97316" opacity=".7"/>
-  <polygon points="190,20 220,70 160,70" fill="#8b5cf6" opacity=".7"/>
-  <rect x="20" y="75" width="60" height="20" rx="10" fill="#10b981" opacity=".7"/>
-  <circle cx="140" cy="90" r="16" fill="#f43f5e" opacity=".7"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="120" viewBox="0 0 240 120">
+  <defs>
+    <linearGradient id="bg-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a"></stop>
+      <stop offset="100%" stop-color="#1e1b4b"></stop>
+    </linearGradient>
+    <linearGradient id="blue-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"></stop>
+      <stop offset="100%" stop-color="#2563eb"></stop>
+    </linearGradient>
+    <linearGradient id="orange-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fb923c"></stop>
+      <stop offset="100%" stop-color="#ea580c"></stop>
+    </linearGradient>
+    <linearGradient id="purple-grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"></stop>
+      <stop offset="100%" stop-color="#7c3aed"></stop>
+    </linearGradient>
+    <linearGradient id="green-grad" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#34d399"></stop>
+      <stop offset="100%" stop-color="#059669"></stop>
+    </linearGradient>
+    <linearGradient id="pink-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f472b6"></stop>
+      <stop offset="100%" stop-color="#db2777"></stop>
+    </linearGradient>
+    <linearGradient id="yellow-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fde047"></stop>
+      <stop offset="100%" stop-color="#ca8a04"></stop>
+    </linearGradient>
+  </defs>
+
+
+  <rect width="240" height="120" fill="url(#bg-grad)"></rect>
+
+
+  <line x1="80" y1="0" x2="80" y2="120" stroke="rgba(255,255,255,0.04)" stroke-width="1"></line>
+  <line x1="160" y1="0" x2="160" y2="120" stroke="rgba(255,255,255,0.04)" stroke-width="1"></line>
+  <line x1="0" y1="40" x2="240" y2="40" stroke="rgba(255,255,255,0.04)" stroke-width="1"></line>
+  <line x1="0" y1="80" x2="240" y2="80" stroke="rgba(255,255,255,0.04)" stroke-width="1"></line>
+
+
+  <rect x="26" y="22" width="44" height="44" rx="4" fill="#2563eb" opacity="0.15" transform="rotate(8,48,44)"></rect>
+  <circle cx="120" cy="60" r="30" fill="#7c3aed" opacity="0.12"></circle>
+
+
+  <rect x="22" y="18" width="44" height="44" rx="6" fill="url(#blue-grad)" transform="rotate(-6,44,40)"></rect>
+  <rect x="22" y="18" width="44" height="44" rx="6" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1" transform="rotate(-6,44,40)"></rect>
+
+
+  <circle cx="120" cy="38" r="22" fill="url(#orange-grad)"></circle>
+  <circle cx="120" cy="38" r="22" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"></circle>
+
+  <ellipse cx="113" cy="31" rx="8" ry="5" fill="rgba(255,255,255,0.2)" transform="rotate(-20,113,31)"></ellipse>
+
+
+  <polygon points="196,14 228,74 164,74" fill="url(#purple-grad)"></polygon>
+  <polygon points="196,14 228,74 164,74" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"></polygon>
+
+
+  <rect x="18" y="74" width="36" height="36" rx="18" fill="url(#green-grad)" transform="rotate(15,36,92)"></rect>
+  <rect x="18" y="74" width="36" height="36" rx="18" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1" transform="rotate(15,36,92)"></rect>
+
+
+  <polygon points="120,72 138,82 138,102 120,112 102,102 102,82" fill="url(#pink-grad)"></polygon>
+  <polygon points="120,72 138,82 138,102 120,112 102,102 102,82" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="1"></polygon>
+
+
+  <polygon points="196,72 218,92 196,112 174,92" fill="url(#yellow-grad)" transform="rotate(10,196,92)"></polygon>
+  <polygon points="196,72 218,92 196,112 174,92" fill="none" stroke="rgba(255,255,255,0.15)" stroke-width="1" transform="rotate(10,196,92)"></polygon>
+
+
+  <circle cx="160" cy="16" r="5" fill="rgba(248,250,252,0.5)"></circle>
+  <circle cx="74" cy="100" r="4" fill="rgba(248,250,252,0.35)"></circle>
+  <circle cx="160" cy="92" r="3" fill="rgba(248,250,252,0.25)"></circle>
+  <rect x="76" y="52" width="6" height="6" rx="1" fill="rgba(248,250,252,0.3)" transform="rotate(20,79,55)"></rect>
 </svg>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -57,11 +57,11 @@
     .notice {
       margin: 24px 0 0;
       padding: 14px 18px;
-      background: #fff3cd;
-      border: 1px solid #ffc107;
+      background: #fffbeb;
+      border: 1px solid #fde68a;
       border-radius: 8px;
       font-size: 13px;
-      color: #664d03;
+      color: #92400e;
     }
 
     .notice strong {
@@ -90,7 +90,7 @@
 
     .step {
       background: #fff;
-      border: 1px solid #e9ecef;
+      border: 1px solid rgba(0, 0, 0, 0.1);
       border-radius: 8px;
       padding: 16px 20px;
       display: flex;
@@ -120,7 +120,7 @@
 
     .step-text p {
       font-size: 13px;
-      color: #6c757d;
+      color: rgba(0, 0, 0, 0.55);
     }
 
     .sample-grid {
@@ -131,7 +131,7 @@
 
     .sample-card {
       background: #fff;
-      border: 1px solid #e9ecef;
+      border: 1px solid rgba(0, 0, 0, 0.1);
       border-radius: 8px;
       overflow: hidden;
     }
@@ -147,14 +147,14 @@
       padding: 8px 12px;
       font-size: 12px;
       font-weight: 500;
-      color: #495057;
+      color: rgba(0, 0, 0, 0.55);
     }
 
     footer {
       text-align: center;
       padding: 28px 16px;
       font-size: 12px;
-      color: #adb5bd;
+      color: rgba(0, 0, 0, 0.36);
     }
   </style>
 </head>
@@ -201,7 +201,7 @@
 
     <section>
       <h2>サンプル画像</h2>
-      <p style="font-size:13px; color:#6c757d; margin-bottom:12px;">
+      <p style="font-size:13px; color:rgba(0,0,0,0.55); margin-bottom:12px;">
         以下の画像を右クリックして動作を確認できます（このページでは変換されず元の形式で保存されます）。
       </p>
       <div class="sample-grid">

--- a/docs/popup.html
+++ b/docs/popup.html
@@ -24,9 +24,9 @@
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
     body {
-      font-family: "Segoe UI", "Hiragino Sans", "Meiryo", sans-serif;
+      font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", Meiryo, sans-serif;
       width: 240px;
-      color: #212529;
+      color: rgba(0, 0, 0, 0.82);
     }
 
     .header {
@@ -34,7 +34,7 @@
       align-items: center;
       gap: 10px;
       padding: 14px 16px 12px;
-      border-bottom: 1px solid #e9ecef;
+      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     }
 
     .header img {
@@ -50,7 +50,7 @@
     .desc {
       padding: 10px 16px;
       font-size: 12px;
-      color: #6c757d;
+      color: rgba(0, 0, 0, 0.55);
       line-height: 1.6;
     }
 
@@ -60,28 +60,28 @@
       gap: 8px;
       padding: 10px 16px;
       text-decoration: none;
-      color: #212529;
+      color: rgba(0, 0, 0, 0.82);
       font-size: 13px;
-      border-top: 1px solid #e9ecef;
+      border-top: 1px solid rgba(0, 0, 0, 0.1);
       transition: background 0.1s;
     }
 
     .menu a:hover {
-      background: #f1f3f5;
+      background: rgba(0, 0, 0, 0.04);
     }
 
     .menu a .icon {
       flex-shrink: 0;
       width: 14px;
       height: 14px;
-      color: #868e96;
+      color: rgba(0, 0, 0, 0.36);
     }
 
     .version {
       padding: 8px 16px;
       font-size: 11px;
-      color: #adb5bd;
-      border-top: 1px solid #e9ecef;
+      color: rgba(0, 0, 0, 0.36);
+      border-top: 1px solid rgba(0, 0, 0, 0.1);
     }
   </style>
 </head>

--- a/website/common.css
+++ b/website/common.css
@@ -155,3 +155,4 @@ footer {
   .footer-inner { flex-direction: column; align-items: flex-start; }
   .footer-links { justify-content: flex-start; }
 }
+

--- a/website/common.css
+++ b/website/common.css
@@ -22,15 +22,16 @@
   --blue-dark: #1d4ed8;
   --blue-light: #dbeafe;
   --blue-pale: #eff6ff;
-  --text: #0f172a;
-  --text-mid: #475569;
-  --text-light: #94a3b8;
-  --border: #e2e8f0;
+  --text: rgba(0, 0, 0, 0.82);
+  --text-mid: rgba(0, 0, 0, 0.55);
+  --text-light: rgba(0, 0, 0, 0.36);
+  --border: rgba(0, 0, 0, 0.1);
+  --border-strong: rgba(0, 0, 0, 0.2);
   --bg: #ffffff;
   --bg-subtle: #f8fafc;
   --radius: 12px;
   --shadow-sm: 0 1px 3px rgba(0,0,0,.08), 0 1px 2px rgba(0,0,0,.06);
-  --shadow:    0 4px 16px rgba(0,0,0,.08), 0 2px 6px rgba(0,0,0,.06);
+  --shadow:    0 0 1rem rgba(0,0,0,0.1), 0 0.125rem 0.25rem rgba(0,0,0,0.2);
   --shadow-lg: 0 20px 40px rgba(0,0,0,.1), 0 8px 16px rgba(0,0,0,.06);
 }
 
@@ -47,7 +48,7 @@ body {
   font-family: "Noto Sans JP", sans-serif;
   color: var(--text);
   background: var(--bg);
-  line-height: 1.7;
+  line-height: 1.8;
   -webkit-font-smoothing: antialiased;
 }
 

--- a/website/index.html
+++ b/website/index.html
@@ -92,7 +92,7 @@
     h1 {
       font-size: clamp(28px, 4vw, 38px);
       font-weight: 700;
-      letter-spacing: -.03em;
+      letter-spacing: -0.02em;
       line-height: 1.25;
       margin-bottom: 16px;
     }
@@ -119,8 +119,8 @@
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      padding: 11px 22px;
-      border-radius: var(--radius);
+      padding: 12px 28px;
+      border-radius: 999px;
       font-size: 14px;
       font-weight: 700;
       text-decoration: none;
@@ -144,7 +144,7 @@
     .btn-secondary {
       background: var(--bg);
       color: var(--text);
-      border: 1.5px solid var(--border);
+      border: 1.5px solid var(--border-strong);
       box-shadow: var(--shadow-sm);
     }
 
@@ -294,7 +294,7 @@
     h2 {
       font-size: 24px;
       font-weight: 700;
-      letter-spacing: -.02em;
+      letter-spacing: 0em;
       margin-bottom: 8px;
     }
 
@@ -1224,9 +1224,9 @@
         <p class="contribute-desc">不具合を発見した場合や改善の提案は、GitHub Issues からお知らせください。セキュリティ上の問題は Issue ではなく Private Vulnerability Reporting からご報告ください。詳細は <a href="https://github.com/takumi0213/kantan-image-converter/blob/main/SUPPORT.md" style="color:var(--blue)">SUPPORT.md</a> をご確認ください。</p>
       </div>
       <div class="contribute-actions">
-        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=bug_report.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 16px;">バグ報告</a>
-        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=feature_request.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 16px;">機能提案</a>
-        <a href="https://github.com/takumi0213/kantan-image-converter/security/advisories/new" class="btn btn-secondary" style="font-size:13px; padding:8px 16px;">脆弱性報告</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=bug_report.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">バグ報告</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=feature_request.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">機能提案</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/security/advisories/new" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">脆弱性報告</a>
       </div>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -708,6 +708,11 @@
       flex-wrap: wrap;
     }
 
+    .btn-compact {
+      font-size: 13px;
+      padding: 8px 18px;
+    }
+
     /* ========== TECH SPEC ========== */
     .spec-grid {
       display: grid;
@@ -1224,9 +1229,9 @@
         <p class="contribute-desc">不具合を発見した場合や改善の提案は、GitHub Issues からお知らせください。セキュリティ上の問題は Issue ではなく Private Vulnerability Reporting からご報告ください。詳細は <a href="https://github.com/takumi0213/kantan-image-converter/blob/main/SUPPORT.md" style="color:var(--blue)">SUPPORT.md</a> をご確認ください。</p>
       </div>
       <div class="contribute-actions">
-        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=bug_report.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">バグ報告</a>
-        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=feature_request.yml" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">機能提案</a>
-        <a href="https://github.com/takumi0213/kantan-image-converter/security/advisories/new" class="btn btn-secondary" style="font-size:13px; padding:8px 18px;">脆弱性報告</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=bug_report.yml" class="btn btn-secondary btn-compact">バグ報告</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/issues/new?template=feature_request.yml" class="btn btn-secondary btn-compact">機能提案</a>
+        <a href="https://github.com/takumi0213/kantan-image-converter/security/advisories/new" class="btn btn-secondary btn-compact">脆弱性報告</a>
       </div>
     </div>
   </div>

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -78,7 +78,7 @@
     h1 {
       font-size: clamp(24px, 3.5vw, 32px);
       font-weight: 700;
-      letter-spacing: -.03em;
+      letter-spacing: -0.02em;
       line-height: 1.3;
       margin-bottom: 12px;
     }
@@ -104,7 +104,7 @@
     h2 {
       font-size: 18px;
       font-weight: 700;
-      letter-spacing: -.02em;
+      letter-spacing: 0em;
       margin-bottom: 16px;
       padding-bottom: 10px;
       border-bottom: 1px solid var(--border);
@@ -166,7 +166,7 @@
 
     .highlight-box p {
       font-size: 15px;
-      color: #1e40af;
+      color: var(--blue-dark);
       line-height: 1.8;
       margin-bottom: 8px;
     }


### PR DESCRIPTION
## 概要

Claude Design での設計セッションで確定したDESIGN.md仕様に基づき、`website/` および `docs/` 配下のファイルをすべて更新します。

## 変更内容

### website/common.css
- テキスト・ボーダー・シャドウ変数をrgbaベースに更新
- `--border-strong: rgba(0,0,0,0.2)` を新規追加（ボタン等の視認性が必要な要素向け）
- `body line-height` を `1.7` → `1.8` に変更

### website/index.html
- `.btn` を `border-radius: 999px`（ピル型）・`padding: 12px 28px` に変更
- `h1 letter-spacing` を `-.03em` → `-0.02em` に修正
- `h2 letter-spacing` を `-.02em` → `0em` に修正
- `.btn-secondary` のボーダーを `var(--border)` → `var(--border-strong)` に変更
- contribute-box 内の小ボタン padding を `8px 18px` に変更

### website/privacy.html
- `h1 / h2 letter-spacing` を仕様値に修正
- `.highlight-box p` の固定hex色 `#1e40af` を `var(--blue-dark)` に統一

### docs/demo.html
- 通知ボックスの色を `#fffbeb / #fde68a / #92400e` に更新
- ボーダー・サブテキストカラーを `rgba()` ベースに統一

### docs/popup.html
- フォントスタック先頭を `"Segoe UI"` → `"Hiragino Kaku Gothic ProN"` に変更
- 本文カラー・ボーダー・hover背景をすべてrgbaベースに統一

### docs/assets/*.svg
- サンプル画像3点を `viewBox="0 0 240 120"` の新デザインに刷新
- `object-fit: cover` でのカード表示に最適化した構図

## 確認事項

- [ ] ビジュアル確認（website/index.html, privacy.html）
- [ ] 拡張機能内ページ確認（docs/demo.html, popup.html）
- [ ] サンプル画像の表示確認（docs/assets/*.svg）

---
_Generated by [Claude Code](https://claude.ai/code/session_017fvdEd8rEneS6haciGCax5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Style**
  * UI色調を統一し、固定のグレーヘックスから透過ベースの黒（rgba）へ切替してテキスト・枠線・通知の色味を更新
  * シャドウを柔らかく調整し、境界線の濃度を改善
  * 行間と見出しの字間を微調整してタイポグラフィを改善
  * ボタンをピル型に刷新し、小型ボタンスタイルを追加して視覚的階層を強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->